### PR TITLE
Add sine wave plotting scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 ## Code
 Development Team's Code
+
+### Plotting a sine wave
+
+To generate an ASCII-art plot of a sine wave, run:
+
+```bash
+python3 plot_sine_wave_ascii.py
+```
+
+For a traditional plot image (requires numpy and matplotlib), use:
+
+```bash
+python3 plot_sine_wave.py
+```
+
+This saves `sine_wave.png` in the current directory.

--- a/plot_sine_wave.py
+++ b/plot_sine_wave.py
@@ -1,0 +1,15 @@
+"""Plot a sine wave using matplotlib and save to sine_wave.png."""
+import numpy as np
+import matplotlib.pyplot as plt
+
+x = np.linspace(0, 2 * np.pi, 100)
+y = np.sin(x)
+
+plt.plot(x, y)
+plt.title('Sine Wave')
+plt.xlabel('x')
+plt.ylabel('sin(x)')
+plt.grid(True)
+plt.tight_layout()
+plt.savefig('sine_wave.png')
+plt.close()

--- a/plot_sine_wave_ascii.py
+++ b/plot_sine_wave_ascii.py
@@ -1,0 +1,16 @@
+"""Generate an ASCII-art plot of a sine wave."""
+import math
+
+# width and height of ASCII plot
+cols = 60
+rows = 20
+
+# generate x values from 0 to 2*pi
+for i in range(rows):
+    x = i / (rows - 1) * 2 * math.pi
+    y = math.sin(x)
+    # transform y from [-1, 1] to [0, cols-1]
+    col = int((y + 1) / 2 * (cols - 1))
+    line = [' '] * cols
+    line[col] = '*'
+    print(''.join(line))


### PR DESCRIPTION
## Summary
- add script using matplotlib (requires numpy/matplotlib)
- add fallback ASCII-art script for environments without extra deps
- document how to run both scripts in README

## Testing
- `python3 plot_sine_wave_ascii.py`
- `pip install numpy matplotlib -q` *(fails: ProxyError 403)*


------
https://chatgpt.com/codex/tasks/task_e_683f63aec04c8328929ad4c7eca117ab